### PR TITLE
Skip named parameters when looking for key/path differences

### DIFF
--- a/spec/radix/tree_spec.cr
+++ b/spec/radix/tree_spec.cr
@@ -352,6 +352,21 @@ module Radix
           result.payload.should eq(:static_page)
         end
 
+        it "finds post in posts" do
+          tree = Tree.new
+          tree.add "/", :root
+          tree.add "/style/:path", :style
+          tree.add "/script/:path", :script
+          tree.add "/:post", :post
+          tree.add "/:category/:post", :catpost
+          tree.add "/:category/:subcategory/:post", :subcatpost
+
+          result = tree.find("/example-post")
+          result.found?.should be_true
+          result.key.should eq("/:post")
+          result.payload.should eq(:post)
+        end
+
         it "returns named parameters in result" do
           tree = Tree.new
           tree.add "/", :root

--- a/spec/radix/tree_spec.cr
+++ b/spec/radix/tree_spec.cr
@@ -367,6 +367,17 @@ module Radix
           result.payload.should eq(:post)
         end
 
+        it "creates children correctly" do
+          tree = Radix::Tree.new
+          tree.add "/", :root
+          tree.add "/:foo", :foo
+          tree.add "/:bar", :bar
+
+          tree.@root.children.size.should eq(2)
+          tree.@root.children[0].children.size.should eq(0)
+          tree.@root.children[1].children.size.should eq(0)
+        end
+
         it "returns named parameters in result" do
           tree = Tree.new
           tree.add "/", :root

--- a/src/radix/tree.cr
+++ b/src/radix/tree.cr
@@ -147,7 +147,11 @@ module Radix
         node.children.each do |child|
           # compare first character
           next unless child.key[0]? == new_key[0]?
-          next if new_key[0] == ':'
+          if child.key[0] == ':' && new_key[0] == ':'
+            new_key_param = extract_key(Char::Reader.new(new_key))
+            next if child.key != new_key_param
+            new_key = new_key[new_key.index('/') as Int32..-1]
+          end
 
           # when found, add to this child
           added = true

--- a/src/radix/tree.cr
+++ b/src/radix/tree.cr
@@ -147,6 +147,7 @@ module Radix
         node.children.each do |child|
           # compare first character
           next unless child.key[0]? == new_key[0]?
+          next if new_key[0] == ':'
 
           # when found, add to this child
           added = true

--- a/src/radix/tree.cr
+++ b/src/radix/tree.cr
@@ -102,15 +102,34 @@ module Radix
       end
     end
 
+    private def extract_key(reader : Char::Reader) : String
+      str = String.build do |str|
+        while reader.has_next? && reader.current_char != '/'
+          str << reader.current_char
+          reader.next_char
+        end
+      end
+      str
+    end
+
+    private def match_named_params?(path_reader, key_reader : Char::Reader) : Bool
+      path_param = extract_key path_reader
+      key_param = extract_key key_reader
+      return path_param == key_param
+    end
+
     # :nodoc:
     private def add(path : String, payload, node : Node)
       key_reader = Char::Reader.new(node.key)
       path_reader = Char::Reader.new(path)
 
       # move cursor position to last shared character between key and path
+      # have to skip over any named params, breaking them up causes problems
       while path_reader.has_next? && key_reader.has_next?
+        if path_reader.current_char == ':' && key_reader.current_char == ':'
+          break if !match_named_params?(path_reader, key_reader)
+        end
         break if path_reader.current_char != key_reader.current_char
-
         path_reader.next_char
         key_reader.next_char
       end
@@ -124,6 +143,7 @@ module Radix
         added = false
 
         new_key = path_reader.string.byte_slice(path_reader.pos)
+
         node.children.each do |child|
           # compare first character
           next unless child.key[0]? == new_key[0]?


### PR DESCRIPTION
I'm fairly new at Crystal so this may not be the best way of doing this, but hopefully the intention is clear. The new test is taken from the example kamber config, without the change it fails to work correctly. The problem seems to be with splitting a named parameter when doing the string comparison for the radix tree.
