### PR TITLE
Corrects lookup issue with catch all and shared key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project aims to comply with [Semantic Versioning](http://semver.org/),
 so please check *Changed* and *Removed* notes before upgrading.
 
 ## [Unreleased]
+### Fixed
+- Correct lookup issue when dealing with catch all and shared partial key (@crisward)
 
 ## [0.3.4] - 2016-11-12
 ### Fixed

--- a/spec/radix/tree_spec.cr
+++ b/spec/radix/tree_spec.cr
@@ -404,6 +404,18 @@ module Radix
           result.found?.should be_true
           result.key.should eq("/members")
         end
+
+        it "does prefer catch all over specific key with partially shared key" do
+          tree = Tree(Symbol).new
+          tree.add "/orders/*anything", :orders_catch_all
+          tree.add "/orders/closed", :closed_orders
+
+          result = tree.find("/orders/cancelled")
+          result.found?.should be_true
+          result.key.should eq("/orders/*anything")
+          result.params.has_key?("anything").should be_true
+          result.params["anything"].should eq("cancelled")
+        end
       end
 
       context "dealing with named parameters" do


### PR DESCRIPTION
Lookup was failing when part of the given path matched a key at the first character, even when the rest of the key didn't match.

It was not possible place a catch all an another key at the same level that started with same character.

This change ensures that all shared part between path and key is compared prior assuming usage of that node as part of the lookup.

Closes #14