### PR TITLE
Crystal 1.0.0 compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,3 +5,5 @@ authors:
   - Luis Lavena <luislavena@gmail.com>
 
 license: MIT
+
+crystal: ">= 0.35.0"


### PR DESCRIPTION
A crystal version property is required for crystal 1.0.0 compability